### PR TITLE
Fixed permissions issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = http://github.com/h2oai/mxnet
 [submodule "thirdparty/javacpp"]
 	path = thirdparty/javacpp
-	url = git@github.com:h2oai/javacpp.git
+	url = http://github.com/h2oai/javacpp


### PR DESCRIPTION
I was trying to update deepwater to the latest version but was getting following error:
```
> git submodule update --init --recursive
Cloning into 'thirdparty/javacpp'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:h2oai/javacpp.git' into submodule path 'thirdparty/javacpp' failed

```
I could resolve it by updating submodule url.