### PR TITLE
fix javacpp git submodule bug

### DIFF
--- a/tensorflow/README.md
+++ b/tensorflow/README.md
@@ -24,11 +24,9 @@ sudo bash bazel-0.3.1-installer-darwin-x86_64.sh
 exit
 ```
 
-#### Javaccp presets
+#### Javacpp presets
 ```
-cd thirdparty
 git submodule update --init --recursive
-cd ..
 ```
 
 ## Install Anaconda Python


### PR DESCRIPTION
If we `git submodule` in thirdparty directory, it would cause such error below:
#### You need to run this command from the toplevel of the working tree.
So, I updated the instructions of `Javacpp presets`, and run it in the top-level directory.